### PR TITLE
Update links to point to the `jupyterlab-contrib` org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab_pytutor
 
-![Github Actions Status](https://github.com/DerThorsten/jupyterlab_pytutor/workflows/Build/badge.svg)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/DerThorsten/jupyterlab_pytutor/HEAD)
+![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab-pytutor/workflows/Build/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab-pytutor/HEAD)
 
 A JupyterLab extension for pythontutor.com.
 This integrates pytutor for python kernels st. the python code can be inspected by pytutor

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/DerThorsten/jupyterlab_pytutor",
+  "homepage": "https://github.com/jupyterlab-contrib/jupyterlab-pytutor",
   "bugs": {
-    "url": "https://github.com/DerThorsten/jupyterlab_pytutor/issues"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-pytutor/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -26,7 +26,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DerThorsten/jupyterlab_pytutor.git"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-pytutor.git"
   },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab-contrib/jupyterlab-contrib.github.io/issues/38