### PR TITLE
Open widget with `split-right`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export class PyTutorExtension
 
       if (this._pytutorPanel === undefined || this._pytutorPanel.isDisposed) {
         this._pytutorPanel = new PyTutorPanel(src);
-        this._shell.add(this._pytutorPanel, 'main');
+        this._shell.add(this._pytutorPanel, 'main', { mode: 'split-right' });
       } else {
         this._pytutorPanel.changeSourceCode(src);
       }


### PR DESCRIPTION
Open the Python tutor widget on the right with `split-right` so it doesn't hide the notebook on open:

https://user-images.githubusercontent.com/591645/213132189-e625e6e8-9cef-4a86-889f-c17cd69b712c.mp4

